### PR TITLE
Fixed the FIXME in subtract.py

### DIFF
--- a/sdi/subtract.py
+++ b/sdi/subtract.py
@@ -17,7 +17,7 @@ def subtract(hduls, name="SCI", method: ("ois", "numpy")="ois"):
     output = []
     outputs = []
     template = combine(hduls, name)["PRIMARY"].data
-     
+
     if method == "ois":
         for hdu in hduls:
             diff = ois.optimal_system(image=hdu[name].data.byteswap().newbyteorder(), refimage=template.byteswap().newbyteorder(), method='Bramich')[0]
@@ -30,9 +30,8 @@ def subtract(hduls, name="SCI", method: ("ois", "numpy")="ois"):
         raise ValueError(f"method {method} unknown!")
 
     for item in output:
-        # FIXME this is ragingly wrong, multiple items should be associated
-        hdu = fits.PrimaryHDU(item)
-        outputs.append(fits.HDUList([hdu])) 
+        newhdu = fits.HDUList([fits.PrimaryHDU(item)] + hdu[1:])
+        outputs.append(newhdu)
     return (hdul for hdul in outputs)
 
 @cli.cli.command("subtract")


### PR DESCRIPTION
This is a fix for issue #102, which fixes the FIXME in subtract. This version of subtract will output fits files that contain a subtracted primary HDU, and whatever HDUs generated in the processes before.