### PR TITLE
Click command and --help command clarity

### DIFF
--- a/sdi/subtract.py
+++ b/sdi/subtract.py
@@ -12,6 +12,7 @@ def subtract(hduls, name="SCI", method: ("ois", "numpy")="ois"):
         hduls -- list of fits hdul's where the last image is the template 
         name -- name of the HDU to use
         image that the other images will be subtracted from
+        method -- method of subtraction. OIS is default (best/slow). Numpy is alternative (worse/quick)
     """
     hduls = [h for h in hduls]
     outputs = []
@@ -35,15 +36,16 @@ def subtract(hduls, name="SCI", method: ("ois", "numpy")="ois"):
 
 @cli.cli.command("subtract")
 @click.option("-n", "--name", default="SCI", help="The HDU to be aligned.")
+@click.option("-m", "--method", default="ois", help="The subtraction method to use; ois or numpy (staight subtraction).")
 @cli.operator
 
 ## subtract function wrapper
-def subtract_cmd(hduls,name="SCI"):
+def subtract_cmd(hduls,name="SCI", method = "ois"):
     """
-    Returns differences of a set of images from a template image
-    Arguments:
-        hduls -- list of fits hdul's where the last image is the template
-        name -- name of the HDU to use
-        image that the other images will be subtracted from
+    Returns differences of a set of images from a template image\n
+    Arguments:\n
+        hduls -- list of fits hdul's where the last image is the template\n
+        name -- name of the HDU to use image that the other images will be subtracted from\n
+        method -- method of subtraction. OIS is default (best/slow). Numpy is alternative (worse/quick)
     """
-    return subtract(hduls, name)
+    return subtract(hduls, name, method)


### PR DESCRIPTION
This version of subtract was missing the @.click function to select the method of subtraction.  I added it from a different version.
Made --help command easier to read.  I added description for the argument 'method' and line breaks to stop lines from running into each other.